### PR TITLE
fix(design-artifacts): publish a live bundle for the horologist catalog

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -57,3 +57,14 @@ jobs:
       # this the whole bundle would be withheld over a known, tracked renderer
       # gap. Flip it back to false once that lands.
       allow-incomplete: true
+      # Carry the executable render bundle onto the delivery branch under bundle/
+      # and record liveBundle in catalog.json, so the preview server re-renders the
+      # previews live (device / theme / knob controls) instead of replaying baked
+      # PNGs. :catalog is an Android/Robolectric render — the same backend the
+      # public server already re-renders for wear-m3 — so the live daemon runs here.
+      publish-live-bundle: true
+      # Split the render into one addressable bundle per preview for the serve
+      # host's per-preview live lane. full keeps each per-preview bundle's re-render
+      # classpath (requires publish-live-bundle), mirroring compose-ai-tools' wear-m3.
+      split-per-preview: true
+      split-mode: full


### PR DESCRIPTION
## Why

`https://preview.coo.ee/status` reports the **Horologist** catalog as "Baked PNG" — it serves static snapshots only, so device / theme / knob controls can't re-render.

Root cause: the `design-artifacts/horologist` delivery branch carries **no `liveBundle`**. Its `catalog.json` has `liveBundle: null` and the branch has no `bundle/` directory, so the serve host records `ServeDegradation.catalogBakedOnly` ("its delivery branch publishes no live bundle") and falls back to baked PNGs. This workflow already uses the shared reusable pipeline but never opted into the live tier — `publish-live-bundle` defaults to `false`.

## What

Set on the `design-artifacts-reusable.yml` call:

- `publish-live-bundle: true` — carry the executable render bundle onto the branch under `bundle/` and record `liveBundle` in `catalog.json`.
- `split-per-preview: true` + `split-mode: full` — split into one addressable per-preview bundle (each keeping its re-render classpath) for the serve host's per-preview live lane.

This mirrors compose-ai-tools' own `wear-m3` job exactly. `:catalog` is an Android/Robolectric render — the same backend the server already re-renders live for `wear-m3` — so the live daemon runs here. `allow-incomplete: true` is retained for the eight known dialog/bottom-sheet previews that capture blank.

## Effect

Takes effect on the next `design-artifacts.yml` run (weekly cron / `workflow_dispatch` / catalog-or-spec push), which force-pushes the regenerated `design-artifacts/horologist` branch. After that the serve host should offer the live lane instead of baked snapshots — verifiable from the `/status` page.

## Test plan

- YAML-only build-wiring change (non-visual); no renders change in this diff.
- Verify by dispatching `Design Artifacts` and confirming `design-artifacts/horologist` gains a `bundle/` dir + `catalog.json.liveBundle`, then that `preview.coo.ee/horologist/` no longer reports `catalog-baked-only`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeDgVqPA33rTt7pso3Fys3)_