### PR TITLE
ci(design-artifacts): publish from previews on scheduled runs too

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -8,25 +8,38 @@ name: Design Artifacts
 # All the work lives in the reusable pipeline in compose-ai-tools; this file is
 # just the trigger set and the inputs.
 #
+# The catalog is developed on `previews`, so that — not `main` — is the branch
+# this publishes from.
+#
 # When it runs:
 #   - weekly (Monday 06:00 UTC) — the delivery branch is a force-pushed
 #     snapshot, and the renderer moves underneath it even when this repo is
 #     unchanged. The cron is what picks that drift up.
 #   - on demand, via workflow_dispatch.
-#   - on push to `main` when the catalog, its spec, or the pinned
+#   - on push to `previews` when the catalog, its spec, or the pinned
 #     compose-ai-tools version changes. That last one is the "compose-ai-tools
 #     was updated" case in the form this repo can actually observe: renovate
 #     bumps `composeAiTools` in the version catalog, and that bump changes the
 #     rendered output. A release upstream that this repo has not yet pinned is
 #     picked up by the cron rather than immediately — closing that gap would
 #     need a repository_dispatch from compose-ai-tools.
+#
+# Note the asymmetry between the two branch-sensitive triggers, which is why
+# `ref:` below is not redundant with `branches:` above. A `push` run uses the
+# workflow file from the pushed commit and checks that commit out, so it needs
+# `branches: [previews]`. A `schedule` run only ever fires for the copy of this
+# file on the *default* branch and checks that branch out — GitHub gives no way
+# to schedule against another ref — so without an explicit `ref: previews` the
+# weekly run would render `main`'s stale catalog and force-push it over the
+# delivery branch, quietly undoing whatever the last push-triggered run
+# published.
 
 on:
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [previews]
     paths:
       - 'catalog/**'
       - 'catalog.spec.json'
@@ -44,19 +57,23 @@ jobs:
       system: horologist
       spec: catalog.spec.json
       module: ':catalog'
+      # The branch the catalog lives on. Needed for the `schedule` run, which
+      # fires only on the default branch and would otherwise render `main`; a
+      # `push` run to `previews` already checks out the right commit and is
+      # unaffected by this. See the note at the top of the file.
+      ref: previews
       # Track the plugin version pinned in this repo's version catalog, so the
       # CLI that renders the bundle can never drift ahead of the applied plugin.
       cli-version: catalog
       catalog-key: composeAiTools
-      # Refuse to publish a degraded render, the default. This was `true` while
-      # the eight dialog- and bottom-sheet-shaped previews were catalogued: they
-      # capture blank (their content composes into its own window and the
-      # renderer captures the host activity's root), which the export reports as
-      # `no semantics for: …` and which sank the whole publish. Those eight are
-      # now withheld from `catalog.spec.json` rather than published as empty
-      # stickers — see catalog/README.md — so the gate is back on for everything
-      # the catalog does declare. Re-add them to the spec, not this flag, when
-      # yschimke/compose-ai-tools#3048 lands.
+      # Refuse to publish a degraded render, the default. This was briefly `true`,
+      # then the eight dialog- and bottom-sheet-shaped previews were withheld from
+      # the spec instead: they captured blank, which the export reported as
+      # `no semantics for: …` and which sank the whole publish. compose-ai-tools
+      # 0.19.13 fixed that capture (yschimke/compose-ai-tools#3048) and the eight
+      # are back in `catalog.spec.json`, so the gate now covers all 80 stickers —
+      # if a dialog regresses to a blank capture the publish fails rather than
+      # shipping empty stickers, which is the point of keeping it on.
       allow-incomplete: false
       # Carry the executable render bundle onto the delivery branch under bundle/
       # and record liveBundle in catalog.json, so the preview server re-renders the


### PR DESCRIPTION
## Summary

The catalog is developed on `previews`, and `previews` already carries a `design-artifacts.yml` that renders it — `push: branches: [previews]` plus an explicit `ref: previews` for the reusable workflow. **`main` was never updated**, and main's copy is the one that matters most.

GitHub raises `schedule` only for the workflow file on the **default** branch, and a scheduled run checks that branch out. So the Monday 06:00 cron has been running main's copy — no `ref:`, so it renders main's older `catalog.spec.json` — and force-pushing the result over `design-artifacts/horologist`. Whichever ran most recently won: every week the cron quietly reverted whatever the last previews push had published.

This ports previews' copy verbatim, so both branches agree.

Worth being precise about what each trigger does after this:

| Trigger | Which copy of the file runs | What gets rendered |
|---|---|---|
| push to `previews` | previews' | the pushed commit — unchanged, already correct |
| `schedule` (Mon 06:00) | **main's** | `previews`, via `ref:` — **this is the fix** |
| `workflow_dispatch` | **main's** | `previews`, via `ref:` — also fixed |

The `push:` clause in this copy is therefore inert, since a push to `previews` runs previews' own file. It's kept identical anyway: a divergence between the two copies is invisible until the trigger that reaches the stale one is the one someone uses, which is exactly how this bug arose.

Only the workflow file moves. `catalog.spec.json`, `catalog/README.md` and the version-catalog pin stay on `previews`, where they belong.

## Note on `agent/publish-from-previews`

That branch (unmerged, no PR) contains this same workflow change bundled with the dialog-sticker restoration and a version-catalog bump. Everything in it is already on `previews`, so this PR takes only the part that needs to be on `main` and leaves the branch alone rather than merging catalog content into a branch that shouldn't carry it.

## Test plan

- `design-artifacts.yml` parses as YAML.
- The file is byte-identical to `origin/previews`'s copy (`git diff origin/previews -- .github/workflows/design-artifacts.yml` is empty).
- `ref` is a real input on `design-artifacts-reusable.yml` (added in compose-ai-tools 0.19.10, #3022) and is documented for precisely this case — its description cites the `previews` scenario and issue #2963.
- Real check is the next Monday cron: it should render 80 stickers from previews' spec rather than main's, and the published `catalog.json` should match what the last previews push produced instead of reverting it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVsxtNYPLpmz4KDhAojLyi)_