### PR TITLE
ci(renovate): track the compose-preview pin on previews, not just main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
     ":dependencyDashboard",
     "schedule:daily"
   ],
+  "description": "Renovate runs against two branches. `main` keeps the existing behaviour — everything, grouped by group:all, on the daily schedule. `previews` carries the design catalog and its compose-preview tooling, and is deliberately restricted to that tooling alone by the last two packageRules; without the restriction, baseBranches would duplicate every dependency PR onto a branch that only exists to hold the catalog.",
+  "baseBranches": [
+    "main",
+    "previews"
+  ],
+  "platformAutomerge": false,
   "commitMessageExtra": "{{{currentValue}}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
   "packageRules": [
     {
@@ -77,6 +83,34 @@
       ],
       "allowedVersions": "<1.4.0",
       "description": "Requires compileSdk 37"
+    },
+    {
+      "description": "`previews` exists only to carry the design catalog, so Renovate has no business updating the rest of the tree there — main already does that. Without this, adding `previews` to baseBranches would open a duplicate of every dependency PR against it. Must stay second-to-last: packageRules are applied in order and the rule below re-enables the one thing previews does need.",
+      "matchBaseBranches": [
+        "previews"
+      ],
+      "matchDepNames": [
+        "/.*/"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "The compose-preview plugin, pinned on `previews` by the composeAiTools key. design-artifacts.yml resolves the render CLI from that same key (cli-version: catalog, catalog-key: composeAiTools), so this pin IS the renderer that produces the published /horologist/ catalog — the sheet goes stale exactly when this goes stale, which is why it sat on 0.19.13 while upstream reached 0.19.18. Ungrouped from group:all and unscheduled so it lands on its own rather than waiting on a repo-wide PR, and automerged so it actually moves: the catalog only republishes when a bump reaches previews, via the gradle/libs.versions.toml path in design-artifacts.yml's push trigger. platformAutomerge is false above, so Renovate waits for every check on the branch instead of handing the PR to GitHub's native auto-merge, which only waits for checks branch protection marks required.",
+      "matchBaseBranches": [
+        "previews"
+      ],
+      "matchPackageNames": [
+        "/^ee\\.schimke\\.composeai($|[.:])/"
+      ],
+      "enabled": true,
+      "groupName": "compose-ai-tools",
+      "schedule": [
+        "at any time"
+      ],
+      "automerge": true,
+      "automergeSchedule": [
+        "at any time"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

This is why `design-artifacts/horologist` still reports `renderer: compose-preview 0.19.13` even though it republished today.

The delivery branch isn't stale — it was regenerated at 11:09 by [run 30744892422](https://github.com/yschimke/horologist/actions/runs/30744892422), which succeeded. The **pin** is stale. `design-artifacts.yml` resolves the render CLI from the version catalog:

```yaml
cli-version: catalog
catalog-key: composeAiTools
```

and `previews` pins `composeAiTools = "0.19.13"`. So the render faithfully used 0.19.13 — that pin *is* the renderer for the published catalog.

Renovate had no `baseBranches`, so it only ever targeted the default branch. The catalog lives on `previews`, which Renovate never looked at, so nothing could move that pin. For contrast `main`'s copy of the same key is on **0.19.11** — older still, and that one *is* in scope; it's stuck behind `group:all`'s single repo-wide PR, which is the same problem from the other end.

## What changes

- `baseBranches: ["main", "previews"]`.
- A rule disabling **everything** on `previews`, second-to-last so ordering works. `previews` exists to carry the catalog; without this, adding it as a base branch would duplicate every dependency PR onto it.
- A last rule re-enabling only `ee.schimke.composeai*` on `previews` — ungrouped from `group:all` and unscheduled so it lands on its own rather than waiting on the repo-wide PR, and `automerge: true` so it actually moves.
- `platformAutomerge: false`, so Renovate waits for every check on the branch instead of handing the PR to GitHub's native auto-merge, which only waits for checks branch protection marks *required*.

**`main`'s behaviour is unchanged** — same `group:all`, same daily schedule, same allowedVersions rules.

## Why automerge

Without it the pin still doesn't move; it just accumulates an open PR. The evidence that this repo's dependency PRs stall is `main` sitting on 0.19.11. And automerge is what closes the loop: a bump landing on `previews` matches `gradle/libs.versions.toml` in `design-artifacts.yml`'s push filter, so the catalog republishes on the new renderer with nobody in the loop. Renovate merges with an app token, which does raise `push`.

Cheap here, too — that run above rendered and published in **8 minutes**, so per-release republishing isn't the CI expense it would be in compose-samples.

If you'd rather review each bump, drop `automerge`/`automergeSchedule` from the last rule and the rest still works; you'll just merge by hand.

## Test plan

- `renovate.json` parses, and every top-level key is a real Renovate option (`baseBranches`, `platformAutomerge`, `description`, `extends`, `commitMessageExtra`, `packageRules`) — no stray keys to trip config validation.
- Rule ordering verified: the disable-all and re-enable rules are the last two, so they override `group:all` and the existing `matchPackagePatterns` rules for `previews` only.
- `matchBaseBranches` scopes both new rules, so `main` resolves exactly as before.
- Real check: after merge, the dependency dashboard should show a `compose-ai-tools` PR **against `previews`** bumping `composeAiTools` 0.19.13 → 0.19.18, which self-merges once green and leaves a `Design Artifacts` run triggered by `push`. The republished `catalog.json` should then read `renderer: compose-preview 0.19.18`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVsxtNYPLpmz4KDhAojLyi)_