### PR TITLE
fix(previews): make renders deterministic

### DIFF
--- a/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
+++ b/auth/sample/wear/src/main/java/com/google/android/horologist/auth/sample/WearApp.kt
@@ -37,13 +37,16 @@ import com.google.android.horologist.auth.sample.screens.tokenshare.customkey.To
 import com.google.android.horologist.auth.sample.screens.tokenshare.defaultkey.TokenShareDefaultKeyScreen
 import com.google.android.horologist.auth.ui.googlesignin.signin.GoogleSignInScreen
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 
 @Composable
 fun WearApp(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberSwipeDismissableNavController(),
+    timeText: @Composable () -> Unit = { ResponsiveTimeText() },
 ) {
-    AppScaffold(modifier = modifier) {
+    AppScaffold(modifier = modifier, timeText = timeText) {
         SwipeDismissableNavHost(
             startDestination = Screen.MainScreen.route,
             navController = navController,
@@ -95,5 +98,5 @@ fun WearApp(
 @WearPreviewSmallRound
 @Composable
 fun DefaultPreview() {
-    WearApp()
+    WearApp(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) })
 }

--- a/compose-tools/api/current.api
+++ b/compose-tools/api/current.api
@@ -41,6 +41,11 @@ package com.google.android.horologist.compose.tools {
     property public static com.google.android.horologist.compose.tools.Device SamsungGalaxyWatch6Large;
   }
 
+  public final class PreviewTimeSource implements androidx.wear.compose.material.TimeSource {
+    property public String currentTime;
+    field public static final com.google.android.horologist.compose.tools.PreviewTimeSource INSTANCE;
+  }
+
   public final class ThemeColors {
     ctor public ThemeColors();
     ctor @KotlinOnly public ThemeColors(optional androidx.compose.ui.graphics.Color primary, optional androidx.compose.ui.graphics.Color primaryVariant, optional androidx.compose.ui.graphics.Color secondary, optional androidx.compose.ui.graphics.Color secondaryVariant, optional androidx.compose.ui.graphics.Color background, optional androidx.compose.ui.graphics.Color surface, optional androidx.compose.ui.graphics.Color error, optional androidx.compose.ui.graphics.Color onPrimary, optional androidx.compose.ui.graphics.Color onSecondary, optional androidx.compose.ui.graphics.Color onBackground, optional androidx.compose.ui.graphics.Color onSurface, optional androidx.compose.ui.graphics.Color onSurfaceVariant, optional androidx.compose.ui.graphics.Color onError);

--- a/compose-tools/src/main/java/com/google/android/horologist/compose/tools/PreviewTimeSource.kt
+++ b/compose-tools/src/main/java/com/google/android/horologist/compose/tools/PreviewTimeSource.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.horologist.compose.tools
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.material.TimeSource
+
+/** A fixed clock for previews whose pixels must not depend on wall time. */
+public object PreviewTimeSource : TimeSource {
+    override val currentTime: String
+        @Composable get() = "10:10"
+}

--- a/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
+++ b/datalayer/sample/wear/src/main/java/com/google/android/horologist/datalayer/sample/WearApp.kt
@@ -27,9 +27,11 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 import com.google.android.horologist.datalayer.sample.screens.MainScreen
 import com.google.android.horologist.datalayer.sample.screens.datalayer.DataLayerScreen
 import com.google.android.horologist.datalayer.sample.screens.info.infoScreen
@@ -45,8 +47,9 @@ import com.google.android.horologist.datalayer.sample.screens.tracking.TrackingS
 fun WearApp(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberSwipeDismissableNavController(),
+    timeText: @Composable () -> Unit = { ResponsiveTimeText() },
 ) {
-    AppScaffold {
+    AppScaffold(timeText = timeText) {
         SwipeDismissableNavHost(
             startDestination = Screen.MainScreen.route,
             navController = navController,
@@ -116,5 +119,5 @@ fun WearApp(
 @WearPreviewSmallRound
 @Composable
 fun DefaultPreview() {
-    WearApp()
+    WearApp(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) })
 }

--- a/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
+++ b/media/audio-ui/src/main/java/com/google/android/horologist/audio/ui/components/animated/AnimatedSetVolumeButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Button
 import androidx.wear.compose.material.ButtonDefaults
@@ -32,6 +33,7 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieAnimatable
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.google.android.horologist.audio.VolumeState
+import com.google.android.horologist.audio.ui.VolumeScreenDefaults.DecreaseIcon
 import com.google.android.horologist.audio.ui.VolumeUiState
 
 /**
@@ -58,13 +60,13 @@ public fun AnimatedSetVolumeButton(
     LaunchedEffect(volumeUiState) {
         val lastVolumeBefore = lastVolume
         lastVolume = volumeUiState.current
-        if (volumeUiState.current > lastVolumeBefore) {
-            lottieAnimatable.animate(
+        when {
+            volumeUiState.current > lastVolumeBefore -> lottieAnimatable.animate(
                 iterations = 1,
                 composition = volumeUp,
             )
-        } else {
-            lottieAnimatable.animate(
+
+            volumeUiState.current < lastVolumeBefore -> lottieAnimatable.animate(
                 iterations = 1,
                 composition = volumeDown,
             )
@@ -76,10 +78,14 @@ public fun AnimatedSetVolumeButton(
         onClick = onVolumeClick,
         colors = ButtonDefaults.iconButtonColors(),
     ) {
-        LottieAnimation(
-            composition = volumeDown,
-            modifier = Modifier.size(24.dp),
-            progress = { lottieAnimatable.progress },
-        )
+        if (LocalInspectionMode.current) {
+            DecreaseIcon()
+        } else {
+            LottieAnimation(
+                composition = volumeDown,
+                modifier = Modifier.size(24.dp),
+                progress = { lottieAnimatable.progress },
+            )
+        }
     }
 }

--- a/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
+++ b/media/ui/src/debug/java/com/google/android/horologist/media/ui/screens/player/PlayerScreenPreview.kt
@@ -43,6 +43,7 @@ import com.google.android.horologist.audio.ui.components.SettingsButtonsDefaults
 import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.pager.PagerScreen
 import com.google.android.horologist.compose.tools.ThemeValues
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 import com.google.android.horologist.compose.tools.WearPreviewThemes
 import com.google.android.horologist.logo.R
 import com.google.android.horologist.media.ui.components.MediaControlButtons
@@ -58,7 +59,7 @@ import kotlin.time.Duration.Companion.seconds
 fun PlayerScreenPreview() {
     Scaffold(
         modifier = Modifier.fillMaxSize().background(BACKGROUND_COLOR),
-        timeText = { ResponsiveTimeText() },
+        timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) },
     ) {
         PagerScreen(
             state = rememberPagerState {
@@ -112,7 +113,7 @@ fun PlayerScreenPreview() {
 fun PlayerScreenPreviewCustomMediaDisplay() {
     Scaffold(
         modifier = Modifier.fillMaxSize().background(BACKGROUND_COLOR),
-        timeText = { ResponsiveTimeText() },
+        timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) },
     ) {
         PagerScreen(
             state = rememberPagerState {
@@ -167,7 +168,7 @@ fun PlayerScreenPreviewCustomMediaDisplay() {
 fun PlayerScreenPreviewCustomBackground() {
     Scaffold(
         modifier = Modifier.fillMaxSize().background(BACKGROUND_COLOR),
-        timeText = { ResponsiveTimeText() },
+        timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) },
     ) {
         PagerScreen(
             state = rememberPagerState {
@@ -259,7 +260,7 @@ fun VolumeScreenTheme(
 fun DefaultMediaPreview() {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        timeText = { ResponsiveTimeText() },
+        timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) },
     ) {
         PagerScreen(
             state = rememberPagerState {
@@ -327,7 +328,7 @@ fun DefaultMediaPreview() {
 fun PlayerScreenPreviewNotingPlayingDisplay() {
     Scaffold(
         modifier = Modifier.fillMaxSize().background(BACKGROUND_COLOR),
-        timeText = { ResponsiveTimeText() },
+        timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) },
     ) {
         PagerScreen(
             state = rememberPagerState {

--- a/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/LottieAnimationWithPlaceholder.kt
+++ b/media/ui/src/main/java/com/google/android/horologist/media/ui/components/animated/LottieAnimationWithPlaceholder.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.wear.compose.material.Icon
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionResult
@@ -38,6 +39,15 @@ public fun LottieAnimationWithPlaceholder(
     modifier: Modifier = Modifier,
     dynamicProperties: LottieDynamicProperties? = null,
 ) {
+    if (LocalInspectionMode.current) {
+        Icon(
+            modifier = modifier,
+            imageVector = placeholder,
+            contentDescription = contentDescription,
+        )
+        return
+    }
+
     // False positive - https://issuetracker.google.com/issues/349411310
     @Suppress("ProduceStateDoesNotAssignValue")
     val isCompositionReady by produceState(initialValue = false, producer = {

--- a/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
+++ b/sample/src/main/java/com/google/android/horologist/ambient/AmbientAwareActivity.kt
@@ -49,6 +49,7 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import com.google.android.horologist.compose.ambient.AmbientAware
 import com.google.android.horologist.compose.ambient.AmbientState
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
@@ -59,6 +60,7 @@ import com.google.android.horologist.compose.material.ToggleChip
 import com.google.android.horologist.compose.material.ToggleChipToggleControl
 import com.google.android.horologist.compose.nav.SwipeDismissableNavHost
 import com.google.android.horologist.compose.nav.composable
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 import kotlinx.serialization.Serializable
 
 class AmbientAwareActivity : ComponentActivity() {
@@ -72,10 +74,12 @@ class AmbientAwareActivity : ComponentActivity() {
 }
 
 @Composable
-fun AmbientAwareWearApp() {
+fun AmbientAwareWearApp(
+    timeText: @Composable () -> Unit = { ResponsiveTimeText() },
+) {
     val navController = rememberSwipeDismissableNavController()
 
-    AppScaffold {
+    AppScaffold(timeText = timeText) {
         Box(modifier = Modifier.fillMaxSize()) {
             SwipeDismissableNavHost(navController, Home) {
                 composable<Home> {
@@ -241,5 +245,5 @@ object Settings
 @WearPreviewLargeRound
 @Composable
 fun WearAppPreview() {
-    AmbientAwareWearApp()
+    AmbientAwareWearApp(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) })
 }

--- a/sample/src/main/java/com/google/android/horologist/audit/AuditMenuScreen.kt
+++ b/sample/src/main/java/com/google/android/horologist/audit/AuditMenuScreen.kt
@@ -27,6 +27,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.listTextPadding
@@ -37,6 +38,7 @@ import com.google.android.horologist.compose.layout.rememberResponsiveColumnStat
 import com.google.android.horologist.compose.material.Chip
 import com.google.android.horologist.compose.material.SecondaryTitle
 import com.google.android.horologist.compose.material.Title
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 
 @Composable
 fun AuditMenuScreen(
@@ -80,7 +82,7 @@ fun AuditMenuScreen(
 @WearPreviewSmallRound
 @WearPreviewLargeRound
 fun AuditMenuScreenPreview() {
-    AppScaffold {
+    AppScaffold(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) }) {
         AuditMenuScreen { }
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/audit/CardsAudit.kt
+++ b/sample/src/main/java/com/google/android/horologist/audit/CardsAudit.kt
@@ -31,11 +31,13 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import com.google.android.horologist.audit.AuditNavigation.Cards.Config
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.padding
 import com.google.android.horologist.compose.layout.ScreenScaffold
 import com.google.android.horologist.compose.layout.rememberResponsiveColumnState
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 import com.google.android.horologist.sample.R
 
 @Composable
@@ -85,7 +87,7 @@ fun BackgroundImageCard() {
 @WearPreviewSmallRound
 @WearPreviewLargeRound
 fun CardsAuditPreview() {
-    AppScaffold {
+    AppScaffold(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) }) {
         CardsAudit(AuditNavigation.Cards.Audit(Config.BackgroundImage))
     }
 }

--- a/sample/src/main/java/com/google/android/horologist/audit/PageIndicatorAudit.kt
+++ b/sample/src/main/java/com/google/android/horologist/audit/PageIndicatorAudit.kt
@@ -31,7 +31,9 @@ import com.google.android.horologist.audit.AuditNavigation.PageIndicator.Config.
 import com.google.android.horologist.audit.AuditNavigation.PageIndicator.Config.Right5Plus
 import com.google.android.horologist.audit.AuditNavigation.PageIndicator.Config.TwoDots
 import com.google.android.horologist.compose.layout.AppScaffold
+import com.google.android.horologist.compose.layout.ResponsiveTimeText
 import com.google.android.horologist.compose.pager.PagerScreen
+import com.google.android.horologist.compose.tools.PreviewTimeSource
 
 @Composable
 fun PageIndicatorAudit(route: AuditNavigation.PageIndicator.Audit) {
@@ -64,7 +66,7 @@ fun PageIndicatorAudit(route: AuditNavigation.PageIndicator.Audit) {
 @WearPreviewSmallRound
 @WearPreviewLargeRound
 fun PageIndicatorLeft5PlusAuditPreview() {
-    AppScaffold {
+    AppScaffold(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) }) {
         PageIndicatorAudit(AuditNavigation.PageIndicator.Audit(Left5Plus))
     }
 }
@@ -73,7 +75,7 @@ fun PageIndicatorLeft5PlusAuditPreview() {
 @WearPreviewSmallRound
 @WearPreviewLargeRound
 fun PageIndicatorRight5PlusAuditPreview() {
-    AppScaffold {
+    AppScaffold(timeText = { ResponsiveTimeText(timeSource = PreviewTimeSource) }) {
         PageIndicatorAudit(AuditNavigation.PageIndicator.Audit(Right5Plus))
     }
 }


### PR DESCRIPTION
## Summary

- pin preview clocks to a shared `10:10` time source
- render static placeholder icons for Lottie components in inspection mode
- avoid starting the volume-down animation when the initial volume has not changed

## Root cause

Recent CI-only pull requests reported 35–36 changed preview variants despite touching no UI. The changed pixels came from wall-clock time and asynchronous/initial Lottie animation frames. A two-pass forced render also found the animated seek previews flipping even when they had not appeared in the recent comments.

## Impact

Preview diff comments should now contain product changes instead of clock and animation noise, making real regressions easier to review.

## Verification

- audited recent `previews` workflow runs and artifacts
- generated the Compose Tools API signature
- ran ktfmt checks for all affected modules
- compiled all affected debug modules successfully
- rendered the affected previews twice with `--force`
- confirmed animated seek and volume PNG hashes are byte-identical across independent renders
- visually confirmed media player previews show the fixed `10:10` clock
