### PR TITLE
Add custom dark themes to the Horologist catalog

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -6,6 +6,9 @@
     "dark",
     "light"
   ],
+  "display": {
+    "surface": "dark"
+  },
   "groups": [
     {
       "name": "Material",

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -61,8 +61,8 @@ Adding an area means adding an annotation and a file. Nothing in the build wirin
 | DataLayer Mobile | Phone | 3 | `:datalayer:phone-ui` |
 | Auth Mobile | Phone | 2 | `:datalayer:phone-ui` |
 
-80 previews in total, of which 72 are published — see the known gap below. Sections cover a
-component's *states*, not just its happy path — disabled
+80 curated component previews are published, plus three generated dark-theme specimen sheets.
+Sections cover a component's *states*, not just its happy path — disabled
 seek buttons at a queue end, an account row with no display name, a five-digit metric, an empty and
 a complete segmented indicator — because those are the cases that break and the ones a static
 screenshot is good at catching.
@@ -118,3 +118,21 @@ Two things worth knowing when reading these stickers:
 
 `design-artifacts.yml` runs with `allow-incomplete: false`, so the completeness gate is on for
 everything the catalog declares.
+
+## Custom themes
+
+The catalog exposes three dark themes: **Blue**, **Lilac**, and **Green**. They reuse palettes that
+Horologist already carries in `:compose-tools` for preview and screenshot coverage rather than
+inventing catalog-only colours.
+
+Each theme is a `@WearThemeCatalog` `PreviewWrapperProvider` whose wrapper installs the selected
+palette into both Wear Material 3 and Wear Material 2. The default Blue provider is inherited from
+the Wear section annotations through `@PreviewWrapperClass`. A live theme selection replaces that
+provider, so preview-local Wear theme wrappers deliberately remain pass-through and cannot shadow
+the selected theme. The five phone bottom-sheet previews keep their existing fixed Material 3
+presentation outside the Wear theme axis; wrapping their separate dialog window with a preview
+provider produces an empty capture.
+
+Discovery therefore reports 83 entries: the 80 curated previews from `catalog.spec.json` and the
+three generated theme specimen sheets. All custom themes use dark backgrounds and dark colour
+schemes; the catalog does not advertise a synthetic Wear light mode.

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
   implementation(projects.composables)
   implementation(projects.composeLayout)
   implementation(projects.composeMaterial)
+  implementation(projects.composeTools)
   implementation(projects.health.composables)
   implementation(projects.images.base)
   // `CoilPaintable`, for the Media section's artwork-bearing previews.
@@ -95,6 +96,7 @@ dependencies {
   implementation(libs.compose.ui.graphics)
   implementation(libs.compose.ui.text)
   implementation(libs.compose.ui.unit)
+  implementation(libs.composeAiPreviewAnnotations)
   implementation(libs.wearcompose.foundation)
   implementation(libs.wearcompose.material)
   implementation(libs.androidx.wear.compose.material3)

--- a/catalog/src/main/java/com/google/android/horologist/catalog/CatalogPreviews.kt
+++ b/catalog/src/main/java/com/google/android/horologist/catalog/CatalogPreviews.kt
@@ -17,6 +17,7 @@
 package com.google.android.horologist.catalog
 
 import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.composeai.preview.PreviewWrapperClass
 
 /**
  * The catalog's section annotations: one per (area, form factor) pair.
@@ -43,6 +44,9 @@ private const val WEAR_BACKGROUND = 0xFF000000
 
 private const val MOBILE_BACKGROUND = 0xFFFFFBFE
 
+private const val DEFAULT_THEME_PROVIDER =
+  "com.google.android.horologist.catalog.HorologistBlueThemeCatalog"
+
 // ---------------------------------------------------------------------------------------------
 // Wear areas. No form factor in the name — Wear is the default reading.
 // ---------------------------------------------------------------------------------------------
@@ -54,10 +58,12 @@ private const val MOBILE_BACKGROUND = 0xFFFFFBFE
   showBackground = true,
   group = "Auth Wear",
 )
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class AuthWearCatalog
 
 /** `:media:ui-material3` — the player, its displays, and its controls. */
 @Preview(device = WEAR_DEVICE, backgroundColor = WEAR_BACKGROUND, showBackground = true, group = "Media")
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class MediaCatalog
 
 /** `:compose-material` — the Material 2 building blocks Horologist wraps. */
@@ -67,6 +73,7 @@ public annotation class MediaCatalog
   showBackground = true,
   group = "Material",
 )
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class MaterialCatalog
 
 /** `:composables` — the standalone widgets that have no Material equivalent. */
@@ -76,6 +83,7 @@ public annotation class MaterialCatalog
   showBackground = true,
   group = "Composables",
 )
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class ComposablesCatalog
 
 /** `:health:composables` — exercise metrics and durations. */
@@ -85,10 +93,12 @@ public annotation class ComposablesCatalog
   showBackground = true,
   group = "Health",
 )
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class HealthCatalog
 
 /** `:media:audio-ui-material3` — volume and audio-output surfaces. */
 @Preview(device = WEAR_DEVICE, backgroundColor = WEAR_BACKGROUND, showBackground = true, group = "Audio")
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class AudioCatalog
 
 /** `:compose-layout` — the scaffolding: scrolling columns, pagers, time text. */
@@ -98,10 +108,12 @@ public annotation class AudioCatalog
   showBackground = true,
   group = "Layout",
 )
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class LayoutCatalog
 
 /** `:ai:ui` — the on-watch prompt/response surfaces. */
 @Preview(device = WEAR_DEVICE, backgroundColor = WEAR_BACKGROUND, showBackground = true, group = "AI")
+@PreviewWrapperClass(DEFAULT_THEME_PROVIDER)
 public annotation class AiCatalog
 
 // ---------------------------------------------------------------------------------------------

--- a/catalog/src/main/java/com/google/android/horologist/catalog/CatalogThemes.kt
+++ b/catalog/src/main/java/com/google/android/horologist/catalog/CatalogThemes.kt
@@ -17,52 +17,88 @@
 package com.google.android.horologist.catalog
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import com.google.android.horologist.compose.tools.ThemeColors
+import com.google.android.horologist.compose.tools.themeValues
+import ee.schimke.composeai.preview.WearThemeCatalog
 
 /**
- * The two themes the catalog renders under.
+ * Dark custom themes shared by both Wear Material generations in the catalog.
  *
- * Both form factors need one, and they are genuinely different types — `wear.compose.material3`'s
- * `MaterialTheme` is not `compose.material3`'s — which is the one place the shared module shows the
- * seam. Everything else about the catalog is form-factor agnostic.
+ * Horologist already carries these palettes in `:compose-tools` for its preview and screenshot
+ * coverage. Each provider installs the same palette into Wear Material 3 and Wear Material 2.
  */
-private val CatalogPrimary = Color(0xFFD3E3FD)
+private val BlueTheme = themeValues.single { it.index == 0 }.themeColors
 
-private val CatalogOnPrimary = Color(0xFF001944)
+private val LilacTheme = themeValues.single { it.index == 2 }.themeColors
 
-private val CatalogPrimaryContainer = Color(0xFF04409F)
+private val GreenTheme = themeValues.single { it.index == 3 }.themeColors
 
-private val CatalogOnPrimaryContainer = Color(0xFFD3E3FD)
+@WearThemeCatalog(name = "Blue", group = "Horologist · Dark")
+public class HorologistBlueThemeCatalog : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    HorologistCatalogTheme(colors = BlueTheme, content = content)
+  }
+}
 
-private val CatalogSurfaceContainer = Color(0xFF29303D)
+@WearThemeCatalog(name = "Lilac", group = "Horologist · Dark")
+public class HorologistLilacThemeCatalog : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    HorologistCatalogTheme(colors = LilacTheme, content = content)
+  }
+}
 
-private val CatalogOnSurface = Color(0xFFEBF1FF)
+@WearThemeCatalog(name = "Green", group = "Horologist · Dark")
+public class HorologistGreenThemeCatalog : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) {
+    HorologistCatalogTheme(colors = GreenTheme, content = content)
+  }
+}
+
+@Composable
+private fun HorologistCatalogTheme(colors: ThemeColors, content: @Composable () -> Unit) {
+  androidx.wear.compose.material.MaterialTheme(colors = colors.toColors()) {
+    val base = androidx.wear.compose.material3.MaterialTheme.colorScheme
+    androidx.wear.compose.material3.MaterialTheme(
+      colorScheme =
+        base.copy(
+          primary = colors.primary,
+          onPrimary = colors.onPrimary,
+          primaryContainer = colors.primaryVariant,
+          onPrimaryContainer = colors.onPrimary,
+          secondary = colors.secondary,
+          onSecondary = colors.onSecondary,
+          secondaryContainer = colors.secondaryVariant,
+          onSecondaryContainer = colors.onSecondary,
+          background = colors.background,
+          onBackground = colors.onBackground,
+          surfaceContainer = colors.surface,
+          onSurface = colors.onSurface,
+          error = colors.error,
+          onError = colors.onError,
+        ),
+      content = content,
+    )
+  }
+}
 
 /**
- * Wear theme, matching the palette the auth and media samples ship so the catalog and the samples
- * are comparable side by side.
+ * The default theme is installed by the catalog annotation's preview wrapper. Keeping these small
+ * pass-through seams avoids touching every preview body while allowing a selected custom provider
+ * to remain the outermost and only theme installer.
  */
 @Composable
 internal fun CatalogWearTheme(content: @Composable () -> Unit) {
-  androidx.wear.compose.material3.MaterialTheme(
-    colorScheme =
-      androidx.wear.compose.material3.MaterialTheme.colorScheme.copy(
-        primary = CatalogPrimary,
-        onPrimary = CatalogOnPrimary,
-        primaryContainer = CatalogPrimaryContainer,
-        onPrimaryContainer = CatalogOnPrimaryContainer,
-        onBackground = Color.White,
-        surfaceContainer = CatalogSurfaceContainer,
-        onSurface = CatalogOnSurface,
-      ),
-    content = content,
-  )
+  content()
 }
 
 /** Wear Material 2 theme, for the `:compose-material` and `:composables` sections. */
 @Composable
 internal fun CatalogWearMaterial2Theme(content: @Composable () -> Unit) {
-  androidx.wear.compose.material.MaterialTheme(content = content)
+  content()
 }
 
 /** Mobile theme, for the `:datalayer:phone-ui` sections. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,6 +180,7 @@ compose-material-ripple = { group = "androidx.compose.material", name = "materia
 compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "compose-material3" } # version 2023.10.01 from BOM is crashing
 compose-remote-creation = { module = "androidx.compose.remote:remote-creation", version.ref = "composeRemote" }
 compose-remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "composeRemote" }
+composeAiPreviewAnnotations = { module = "ee.schimke.composeai:preview-annotations", version.ref = "composeAiTools" }
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }


### PR DESCRIPTION
## Summary

- add Blue, Lilac, and Green `@WearThemeCatalog` providers, all using dark Horologist palettes already present in `:compose-tools`
- apply the default Blue provider to every curated Wear preview while allowing the catalog theme selector to replace it
- install each selected palette across both Wear Material 2 and Wear Material 3
- mark the catalog display surface as dark and document the custom theme behavior

The five phone bottom-sheet previews keep their existing fixed Material 3 presentation because they render in a separate dialog window and cannot safely inherit a preview wrapper.

Addresses https://github.com/yschimke/compose-ai-tools/issues/3267 for the Horologist project.

## Validation

- `./gradlew :catalog:compileDebugKotlin :catalog:composePreviewDiscover`
- `./gradlew :catalog:ktfmtCheck`
- rendered all three generated theme specimen sheets with compose-preview
- verified 83 discovered entries (80 curated previews + 3 theme sheets) and distinct image hashes for Blue, Lilac, and Green