### PR TITLE
Fix fillMaxRectangle constraint geometry

### DIFF
--- a/compose-layout/src/main/java/com/google/android/horologist/compose/layout/FillMaxRectangle.kt
+++ b/compose-layout/src/main/java/com/google/android/horologist/compose/layout/FillMaxRectangle.kt
@@ -17,24 +17,23 @@
 package com.google.android.horologist.compose.layout
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Constraints
+import kotlin.math.min
 import kotlin.math.sqrt
 
 /**
- * A [Modifier] for adding padding for round devices for rectangular content.
+ * A [Modifier] for sizing rectangular content within round devices.
  *
- * If the device is round, an equal amount of padding required to inset the content inside the
- * circle.
+ * If the device is round, the content is measured as the largest square whose corners touch the
+ * circular boundary of the available layout constraints.
  *
- * This method assumes that the layout will fill the entire screen, and that there are no oval
- * devices.
+ * This method assumes that the available layout is square and that there are no oval devices.
  */
 @Stable
 public fun Modifier.fillMaxRectangle(): Modifier = composed(
@@ -43,12 +42,29 @@ public fun Modifier.fillMaxRectangle(): Modifier = composed(
     },
 ) {
     val isRound = LocalConfiguration.current.isScreenRound
-    var inset: Dp = 0.dp
-    if (isRound) {
-        val screenHeightDp = LocalConfiguration.current.screenHeightDp
-        val screenWidthDp = LocalConfiguration.current.smallestScreenWidthDp
-        val maxSquareEdge = (sqrt(((screenHeightDp * screenWidthDp) / 2).toDouble()))
-        inset = Dp(((screenHeightDp - maxSquareEdge) / 2).toFloat())
+    if (!isRound) {
+        return@composed fillMaxSize()
     }
-    fillMaxSize().padding(all = inset)
+
+    layout { measurable, constraints ->
+        if (!constraints.hasBoundedWidth || !constraints.hasBoundedHeight) {
+            val placeable = measurable.measure(constraints)
+            return@layout layout(placeable.width, placeable.height) {
+                placeable.placeRelative(0, 0)
+            }
+        }
+
+        val width = constraints.maxWidth
+        val height = constraints.maxHeight
+        val diameter = min(width, height)
+        val maxSquareEdge = (diameter / sqrt(2.0)).toInt()
+        val placeable = measurable.measure(Constraints.fixed(maxSquareEdge, maxSquareEdge))
+
+        layout(width, height) {
+            placeable.placeRelative(
+                x = (width - maxSquareEdge) / 2,
+                y = (height - maxSquareEdge) / 2,
+            )
+        }
+    }
 }

--- a/compose-layout/src/test/java/com/google/android/horologist/compose/layout/FillMaxRectangleTest.kt
+++ b/compose-layout/src/test/java/com/google/android/horologist/compose/layout/FillMaxRectangleTest.kt
@@ -18,12 +18,14 @@ package com.google.android.horologist.compose.layout
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
 import androidx.test.filters.MediumTest
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import org.junit.Assert.assertEquals
@@ -68,6 +70,29 @@ class FillMaxRectangleTest {
         }
 
         val width = composeTestRule.onRoot().fetchSemanticsNode().size.width
+        val safeWidth = composeTestRule.onNodeWithTag("boxInset").fetchSemanticsNode().size.width
+
+        val expectedWidth = sqrt(2.0 * (width.toDouble() / 2).pow(2.0))
+        assertEquals(expectedWidth, safeWidth.toDouble(), 1.0)
+    }
+
+    @Test
+    @Config(
+        sdk = [35],
+        qualifiers = RobolectricDeviceQualifiers.WearOSLargeRound,
+    )
+    fun testCircleUsesAvailableConstraints() {
+        composeTestRule.setContent {
+            Box(modifier = Modifier.size(100.dp).testTag("container")) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxRectangle()
+                        .testTag("boxInset"),
+                )
+            }
+        }
+
+        val width = composeTestRule.onNodeWithTag("container").fetchSemanticsNode().size.width
         val safeWidth = composeTestRule.onNodeWithTag("boxInset").fetchSemanticsNode().size.width
 
         val expectedWidth = sqrt(2.0 * (width.toDouble() / 2).pow(2.0))


### PR DESCRIPTION
## Goal

Raise the preview renderer's inconsistent `smallestScreenWidthDp` device override upstream, and fix Horologist's `fillMaxRectangle()` to use its actual layout constraints so the square's corners meet the circular boundary.

## Summary

- **Changed:** `FillMaxRectangle.kt` now derives the inscribed square from bounded layout constraints and centers it; non-round behavior remains `fillMaxSize()`.
- **Changed:** `FillMaxRectangleTest.kt` adds a constrained-parent regression test independent of the device resource bucket.
- **Tried and abandoned:** the standalone preview CLI scanned unrelated modules and cancelled; the targeted Gradle preview task rendered successfully.
- **Known gap:** renderer-side configuration consistency is tracked separately in [compose-ai-tools#3309](https://github.com/yschimke/compose-ai-tools/issues/3309).
- **Verification:** `FillMaxRectangleTest` passes. Re-rendered and inspected `LayoutFillMaxRectangle_Layout`; the 321 px square is centered in the 454 px round viewport with its corners on the circle boundary.