### PR TITLE
ci: pin the compose-preview apply action to v0.19.38

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -110,7 +110,11 @@ jobs:
           distribution: 'zulu'
           java-version: 21
 
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@main
+      # Pinned to the same release as design-artifacts.yml's reusable-workflow
+      # ref and driver-ref. Floating this one on @main meant the PR render could
+      # run a newer renderer than the publish did, so a preview could look right
+      # here and different on the delivery branch. Bump all three together.
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.19.38
         with:
           # Only the compose pipeline. The a11y / notifications / resources
           # pipelines are additional renders on top of this one; turn them on


### PR DESCRIPTION
#### WHAT

`compose-preview.yml` pinned: `…/.github/actions/apply@main` → `@v0.19.38`.

#### WHY

This repo now pins two of its three compose-ai-tools refs to the release — `design-artifacts-reusable.yml@v0.19.38` and `driver-ref: v0.19.38` — but the PR-render action still floated on `@main`. That mix means the render that gates a PR can run a newer renderer than the one that publishes the catalog, so a preview can look correct in the PR comment and different on `design-artifacts/horologist`. All three now move together on a bump.

#### HOW

One-line workflow ref change, no source changes. Nothing to render: this changes which renderer version the PR-render job fetches, not any composable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVTPbkUHDTZYDYE6Wbp3dG)_