### PR TITLE
fix(design-artifacts): track the reusable workflow on main and drop the dead driver-ref

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -75,7 +75,15 @@ jobs:
     if: ${{ github.repository == 'yschimke/horologist' }}
     permissions:
       contents: write
-    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@v1.12.0
+    # `@main`, the documented usage (see the header of design-artifacts-reusable.yml
+    # and docs/design/DESIGN_CATALOGS.md), and what every other catalog repo uses.
+    # This file used to pin a release tag, which bought less than it looked like: the
+    # export driver is NOT taken from this ref — it is the release commit named by
+    # compose-ai-tools' `.github/design-artifacts-driver-pin.txt`, which the workflow
+    # reads from `main` whatever ref the caller pins. So a tag here froze the workflow
+    # (missing pipeline fixes the other repos pick up) without freezing the driver it
+    # runs — the worst half of both. Tracking `main` makes the two consistent.
+    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
     with:
       system: horologist
       spec: catalog.spec.json
@@ -97,11 +105,14 @@ jobs:
       # CLI that renders the bundle can never drift ahead of the applied plugin.
       cli-version: catalog
       catalog-key: composeAiTools
-      # Keep the export driver on the same release as the renderer, so the driver
-      # and the CLI that produced the PNGs it reads can't skew apart. The pinned
-      # @design-parity/catalog-export provenance is recorded in catalog.json when
-      # the delivery branch is regenerated.
-      driver-ref: v1.12.0
+      # `driver-ref` deliberately absent. It is a deprecated compatibility input and
+      # is IGNORED: the export driver revision is decided by the reusable workflow
+      # itself, from the immutable release commit in compose-ai-tools'
+      # `.github/design-artifacts-driver-pin.txt`. Passing `driver-ref: v1.12.0` here
+      # read as if it held the driver on a chosen release — the comment that used to
+      # sit on this line said exactly that — while doing nothing at all. Better absent
+      # than present and misleading; the driver's provenance is still recorded in
+      # catalog.json when the delivery branch is regenerated.
       # Refuse to publish a degraded render, the default. This was briefly `true`,
       # then the eight dialog- and bottom-sheet-shaped previews were withheld from
       # the spec instead: they captured blank, which the export reported as


### PR DESCRIPTION
## Summary

This repo was the only catalog caller still pinning the reusable workflow to a release tag, and it also passed `driver-ref`. Both were misleading, and together they were the worst of both worlds.

**`driver-ref` is ignored.** It is a deprecated compatibility input; the reusable workflow's own description says so:

> Deprecated compatibility input. The privileged export driver revision is decided by this workflow — the immutable release commit in `.github/design-artifacts-driver-pin.txt` for external callers … and **caller-supplied refs are ignored**.

The comment sitting on that line claimed it *"keep[s] the export driver on the same release as the renderer, so the driver and the CLI that produced the PNGs it reads can't skew apart."* It did nothing of the sort. Removed rather than corrected — an input that reads as load-bearing but is discarded is worse than its absence.

**The tag pin froze the wrong half.** Because the driver comes from the pin file (read from `main` regardless of the caller's ref), pinning `@v1.12.0` froze the *workflow* — so this repo silently missed pipeline fixes that compose-samples, home-assistant-android, pocket-casts-android and meshcore-mobile pick up on `@main` — while the driver moved underneath it anyway. Now on `@main`, the documented usage, consistent with every sibling.

Untouched: the `apply@v1.12.0` composite-action pins in `compose-preview.yml`. Those are genuine version pins and Renovate bumps them in the existing `compose-ai-tools` group.

## Why now

This surfaced while tracing why a driver fix (compose-ai-tools#4115) had not reached the catalogs. The answer — the driver comes from a release-pinned file, not from the caller's ref — is exactly the mechanism this file was documenting incorrectly.

## Test plan

- Workflow parses as YAML; the `publish` job now resolves `uses: …design-artifacts-reusable.yml@main` and its `with:` keys no longer include `driver-ref`.
- No behavioural change is expected from dropping `driver-ref`, precisely because it was ignored.
- `.github/workflows/design-artifacts.yml` is on this workflow's push trigger for `previews`, so merging re-runs the publish and regenerates `design-artifacts/horologist` against the current pinned driver.

Text-only is correct: workflow plumbing, no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WA5cgxHyG8n5wgaLVKVV3)_